### PR TITLE
Add Hexens audit link to security page

### DIFF
--- a/security.mdx
+++ b/security.mdx
@@ -4,6 +4,10 @@ description: ''
 icon: lock
 ---
 
-The Layerswap API serves as the foundation for the future TRAIN protocol, which represents the cutting-edge in permissionless & trustless bridging technology. While Layerswap has already processed billions of dollars in transaction volume, showcasing its robustness and safety, the upcoming [TRAIN protocol](https://docs.train.tech) will set new standards in security and decentralization.
+## Smart Contract Audit
 
-Layerswap leverages proven mechanisms to ensure secure and reliable transactions, protecting both user funds and data integrity. However, the TRAIN protocol introduces advanced security enhancements, including trustless operations and atomic swaps, delivering the ultimate assurance for your bridging needs.
+The LayerswapDepository smart contract has been audited by [Hexens](https://hexens.io). You can view the [full audit report here](https://github.com/Hexens/Smart-Contract-Review-Public-Reports/blob/main/hexens-layerswap-mar-26\(Final\).pdf).
+
+## TRAIN Protocol
+
+Layerswap has already processed billions of dollars in transaction volume, showcasing its robustness and safety. The upcoming [TRAIN protocol](https://docs.train.tech) will set new standards in security and decentralization, introducing trustless cross-chain transfers powered by atomic swaps.


### PR DESCRIPTION
## Summary
- Add Hexens smart contract audit link for LayerswapDepository to the security page
- Restructure page: audit info first, TRAIN protocol section second
- Clean up TRAIN protocol copy to remove misleading framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)