### PR TITLE
Move security page to Overview tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -20,7 +20,8 @@
               "Integrate",
               "api-keys",
               "fees",
-              "networks-tokens"
+              "networks-tokens",
+              "security"
             ]
           }
         ]
@@ -137,8 +138,7 @@
                   "api-reference/refunds"
                 ]
               },
-              "api-reference/webhook",
-              "security"
+              "api-reference/webhook"
             ]
           },
           {


### PR DESCRIPTION
## Summary
- Move the security page from the API Integration tab to the Overview tab (under "About Layerswap")
- Security info is general, not API-specific, so it fits better in the Overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)