### PR TITLE
Remove icon from security page

### DIFF
--- a/security.mdx
+++ b/security.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Security'
 description: ''
-icon: lock
 ---
 
 ## Smart Contract Audit


### PR DESCRIPTION
## Summary
- Remove `icon: lock` from security.mdx frontmatter for consistency with the other pages in the Overview section, which don't have icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)