### PR TITLE
Replace navbar Use App button with Book a demo link

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -217,8 +217,8 @@
     ],
     "primary": {
       "type": "button",
-      "label": "Use App",
-      "href": "https://layerswap.io/app"
+      "label": "Book a demo",
+      "href": "https://cal.com/babgev/layerswap-demo"
     }
   },
   "seo": {


### PR DESCRIPTION
Changes the docs navbar primary button from "Use App" (linking to the Layerswap app) to "Book a demo", pointing to the cal.com booking page (https://cal.com/babgev/layerswap-demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)