### PR TITLE
Remove Discord references

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -235,7 +235,6 @@
       "x": "https://x.com/layerswap",
       "github": "https://github.com/layerswap",
       "telegram": "https://t.me/layerswap_io",
-      "discord": "https://discord.gg/layerswap",
       "linkedin": "https://linkedin.com/company/layerswap"
     },
     "links": [

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -50,6 +50,4 @@ Layerswap is committed to providing exceptional experience for cross-chain trans
  </Card> 
 <Card title="X (Twitter)" href="https://x.com/layerswap" icon="x-twitter" cta="Follow us to get updates on new features!"> 
 </Card> 
-<Card title="Discord" icon="discord" href="https://discord.gg/layerswap" cta="Join our Discord community!">
- </Card> 
 </Columns>

--- a/snippets/depositWidget.jsx
+++ b/snippets/depositWidget.jsx
@@ -4061,9 +4061,6 @@ export const DepositWidget = () => {
                                             <a href="https://x.com/layerswap" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 transition hover:text-brand! border-none">
                                                 X
                                             </a>
-                                            <a href="https://discord.com/invite/layerswap" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 transition hover:text-brand! border-none">
-                                                Discord
-                                            </a>
                                             <a href="https://github.com/layerswap" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 transition hover:text-brand! border-none">
                                                 GitHub
                                             </a>


### PR DESCRIPTION
Removes all Discord links from the docs.

- **docs.json** — removed the `discord` entry from footer socials.
- **introduction.mdx** — removed the Discord `<Card>` from the "Get connected with us" section (Partnership, Support & Feedback, and X cards remain).
- **snippets/depositWidget.jsx** — removed the Discord link from the widget footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)